### PR TITLE
Allow Xframe request from cloudcv.org

### DIFF
--- a/demo/settings.py
+++ b/demo/settings.py
@@ -103,4 +103,4 @@ CHANNEL_LAYERS = {
     },
 }
 
-X_FRAME_OPTIONS = 'https://cloudcv.org/projects/grad-cam'
+X_FRAME_OPTIONS = 'ALLOW-FROM https://cloudcv.org/projects/grad-cam'

--- a/demo/settings.py
+++ b/demo/settings.py
@@ -102,3 +102,5 @@ CHANNEL_LAYERS = {
         "ROUTING": "grad_cam.routing.channel_routing",
     },
 }
+
+X_FRAME_OPTIONS = 'https://cloudcv.org/projects/grad-cam'


### PR DESCRIPTION
This PR allows this demo to be listed as an <iframe> on the https://cloudcv.org/ website under the projects section.
@deshraj Please review the PR.